### PR TITLE
Bug fix:  time variables overflow

### DIFF
--- a/FreeRTOS/FreeRTOSConfig.h
+++ b/FreeRTOS/FreeRTOSConfig.h
@@ -198,7 +198,7 @@ standard names. */
 
 #ifndef pdTICKS_TO_MS
 #define pdTICKS_TO_MS(ticks) \
-  (((ticks) * (configTICK_RATE_HZ)) / 1000)
+  ((((long long)(ticks)) * (configTICK_RATE_HZ)) / 1000)
 #endif
 
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/cpp11_gcc/freertos_time.cpp
+++ b/FreeRTOS/cpp11_gcc/freertos_time.cpp
@@ -73,10 +73,10 @@ using namespace std::chrono;
 void SetSystemClockTime(
     const time_point<system_clock, system_clock::duration> &time)
 {
-  auto delta = time - time_point<system_clock>(
-                          milliseconds(pdTICKS_TO_MS(xTaskGetTickCount())));
-  long long sec = duration_cast<seconds>(delta).count();
-  long usec = duration_cast<microseconds>(delta).count() - sec * 1'000'000;
+  auto delta{time - time_point<system_clock>(
+                        milliseconds(pdTICKS_TO_MS(xTaskGetTickCount())))};
+  long long sec{duration_cast<seconds>(delta).count()};
+  long usec = duration_cast<microseconds>(delta).count() - sec * 1'000'000; //narrowing type
 
   free_rtos_std::wall_clock::time({sec, usec});
 }
@@ -97,10 +97,12 @@ extern "C" int _gettimeofday(timeval *tv, void *tzvp)
 {
   (void)tzvp;
 
-  auto t = free_rtos_std::wall_clock::time();
+  auto t{free_rtos_std::wall_clock::time()};
 
-  long long sec = pdTICKS_TO_MS(t.ticks) / 1000;
-  long usec = pdTICKS_TO_MS(t.ticks - (sec * configTICK_RATE_HZ)) * 1000;
+  long long ms{pdTICKS_TO_MS(t.ticks)};
+  long long sec{ms / 1000};
+  long usec = (ms - sec * 1000) * 1000; //narrowing type
+
   *tv = t.offset + timeval{sec, usec};
 
   return 0; // return non-zero for error

--- a/FreeRTOS/cpp11_gcc/freertos_time.cpp
+++ b/FreeRTOS/cpp11_gcc/freertos_time.cpp
@@ -83,7 +83,7 @@ void SetSystemClockTime(
 
 static timeval operator+(const timeval &l, const timeval &r)
 {
-  timeval t{l.tv_sec + r.tv_sec, l.tv_usec + l.tv_usec};
+  timeval t{l.tv_sec + r.tv_sec, l.tv_usec + r.tv_usec};
 
   if (t.tv_usec >= 1'000'000)
   {

--- a/FreeRTOS/cpp11_gcc/gthr-FreeRTOS.h
+++ b/FreeRTOS/cpp11_gcc/gthr-FreeRTOS.h
@@ -151,13 +151,8 @@ extern "C"
   static inline __gthread_time_t operator-(
       const __gthread_time_t &lhs, const timeval &rhs)
   {
-    long s {lhs.sec - rhs.tv_sec};
-    long ns {lhs.nsec - rhs.tv_usec * 1000};
-    if (ns < 0)
-    {
-      s--;
-      ns += 1'000'000;
-    }
+    int32_t s{lhs.sec - rhs.tv_sec};
+    int32_t ns{lhs.nsec - rhs.tv_usec * 1000};
 
     return __gthread_time_t{s, ns};
   }
@@ -224,7 +219,7 @@ extern "C"
       __gthread_cond_t *cond, __gthread_mutex_t *mutex,
       const __gthread_time_t *abs_timeout)
   {
-    auto this_thrd_hndl {__gthread_t::native_task_handle()};
+    auto this_thrd_hndl{__gthread_t::native_task_handle()};
     cond->lock();
     cond->push(this_thrd_hndl);
     cond->unlock();
@@ -232,11 +227,11 @@ extern "C"
     timeval now{};
     gettimeofday(&now, NULL);
 
-    auto ms {(*abs_timeout - now).milliseconds()};
+    auto ms{(*abs_timeout - now).milliseconds()};
 
     __gthread_mutex_unlock(mutex);
 
-    int result {0};
+    int result{0};
     if (0 == ulTaskNotifyTake(pdFALSE, pdMS_TO_TICKS(ms)))
     { // timeout - remove the thread from the waiting list
       cond->lock();


### PR DESCRIPTION
32bit variables overflow caused that in some cases number of milliseconds passed to FreeRTOS waiting functions was negative (or too big).

- operations modified to do maths on 64bit numbers
- variable initialization changed from an assignment to `{}` to capture type narrowing in compile time
- in one case wrong variable was used