### PR TITLE
TimedCV test with multiple threads

### DIFF
--- a/FreeRTOS/FreeRTOSConfig.h
+++ b/FreeRTOS/FreeRTOSConfig.h
@@ -107,7 +107,7 @@ uint32_t SystemCoreClockFreq();
 /* Memory allocation related definitions. */
 #define configSUPPORT_STATIC_ALLOCATION 0
 #define configSUPPORT_DYNAMIC_ALLOCATION 1
-#define configTOTAL_HEAP_SIZE 8 * 1024
+#define configTOTAL_HEAP_SIZE 32 * 1024
 #define configAPPLICATION_ALLOCATED_HEAP 0
 
 /* Hook function related definitions. */

--- a/FreeRTOS/cpp11_gcc/gthr-FreeRTOS.h
+++ b/FreeRTOS/cpp11_gcc/gthr-FreeRTOS.h
@@ -230,17 +230,17 @@ extern "C"
     auto ms{(*abs_timeout - now).milliseconds()};
 
     __gthread_mutex_unlock(mutex);
+    auto fTimeout{0 == ulTaskNotifyTake(pdFALSE, pdMS_TO_TICKS(ms))};
+    __gthread_mutex_lock(mutex);
 
     int result{0};
-    if (0 == ulTaskNotifyTake(pdFALSE, pdMS_TO_TICKS(ms)))
+    if (fTimeout)
     { // timeout - remove the thread from the waiting list
       cond->lock();
       cond->remove(this_thrd_hndl);
       cond->unlock();
       result = 138; // posix ETIMEDOUT
     }
-
-    __gthread_mutex_lock(mutex);
 
     return result;
   }


### PR DESCRIPTION
- Test of condition_variable with timeout involves multiple threads accessing single queue. It required to increase heap size.
- CondVar test description added + formatting
- cond_timedwait sync fixed
- add generic timeout test