### PR TITLE
Futures implementation

### DIFF
--- a/FreeRTOS/CMakelists.txt
+++ b/FreeRTOS/CMakelists.txt
@@ -46,7 +46,10 @@ include_directories(
 add_library(freeRTOS STATIC
   cpp11_gcc/condition_variable.cpp
   cpp11_gcc/freertos_time.cpp
+  cpp11_gcc/gthr_key.cpp
   cpp11_gcc/thread.cpp
+  cpp11_gcc/future.cc
+  cpp11_gcc/mutex.cc
 
   Source/croutine.c
   Source/event_groups.c

--- a/FreeRTOS/FreeRTOSConfig.h
+++ b/FreeRTOS/FreeRTOSConfig.h
@@ -96,8 +96,11 @@ uint32_t SystemCoreClockFreq();
 #define configNUM_THREAD_LOCAL_STORAGE_POINTERS 5
 #define configUSE_APPLICATION_TASK_TAG 0
 
+#define configLIST_VOLATILE volatile
+
 #define configMAIN_STACK_SIZE 256 // in words (bytes = x4)
 #define configDEFAULT_STACK_SIZE configMINIMAL_STACK_SIZE
+#define configRECORD_STACK_HIGH_ADDRESS 1
 
 /* Used memory allocation (heap_x.c) */
 #define configFRTOS_MEMORY_SCHEME 4
@@ -107,7 +110,7 @@ uint32_t SystemCoreClockFreq();
 /* Memory allocation related definitions. */
 #define configSUPPORT_STATIC_ALLOCATION 0
 #define configSUPPORT_DYNAMIC_ALLOCATION 1
-#define configTOTAL_HEAP_SIZE 32 * 1024
+#define configTOTAL_HEAP_SIZE 64 * 1024
 #define configAPPLICATION_ALLOCATED_HEAP 0
 
 /* Hook function related definitions. */

--- a/FreeRTOS/cpp11_gcc/condition_variable.cpp
+++ b/FreeRTOS/cpp11_gcc/condition_variable.cpp
@@ -54,7 +54,7 @@ void condition_variable::wait(std::unique_lock<std::mutex> &m)
 
   m.unlock();
 
-  ulTaskNotifyTake(pdFALSE, portMAX_DELAY);
+  ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
 
   m.lock();
 }
@@ -81,6 +81,112 @@ void condition_variable::notify_all()
     xTaskNotifyGive(t);
   }
   _M_cond.unlock();
+}
+
+// condition_variable -*- C++ -*-
+//
+// Copyright (C) 2008-2019 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+//
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+//
+//
+// Code below has been copied from gcc distribution
+// at: gcc/libstdc++-v3/src/c++11/condition_variable.cc
+//
+// It provides an implementation of std::notify_all_at_thread_exit
+// and a mechanism required by 'futures' from the C++ standard.
+//
+
+extern void
+__at_thread_exit(__at_thread_exit_elt *);
+
+namespace
+{
+__gthread_key_t key;
+
+void run(void *p)
+{
+  auto elt = (__at_thread_exit_elt *)p;
+  while (elt)
+  {
+    auto next = elt->_M_next;
+    elt->_M_cb(elt);
+    elt = next;
+  }
+}
+
+void run()
+{
+  auto elt = (__at_thread_exit_elt *)__gthread_getspecific(key);
+  __gthread_setspecific(key, nullptr);
+  run(elt);
+}
+
+struct notifier final : __at_thread_exit_elt
+{
+  notifier(condition_variable &cv, unique_lock<mutex> &l)
+      : cv(&cv), mx(l.release())
+  {
+    _M_cb = &notifier::run;
+    __at_thread_exit(this);
+  }
+
+  ~notifier()
+  {
+    mx->unlock();
+    cv->notify_all();
+  }
+
+  condition_variable *cv;
+  mutex *mx;
+
+  static void run(void *p) { delete static_cast<notifier *>(p); }
+};
+
+void key_init()
+{
+  struct key_s
+  {
+    key_s() { __gthread_key_create(&key, run); }
+    ~key_s() { __gthread_key_delete(key); }
+  };
+  static key_s ks;
+  // Also make sure the callbacks are run by std::exit.
+  std::atexit(run);
+}
+} // namespace
+
+void __at_thread_exit(__at_thread_exit_elt *elt)
+{
+  static __gthread_once_t once = __GTHREAD_ONCE_INIT;
+  __gthread_once(&once, key_init);
+
+  elt->_M_next = (__at_thread_exit_elt *)__gthread_getspecific(key);
+  __gthread_setspecific(key, elt);
+}
+
+void notify_all_at_thread_exit(condition_variable &cv, unique_lock<mutex> l)
+{
+  (void)new notifier{cv, l};
 }
 
 } // namespace std

--- a/FreeRTOS/cpp11_gcc/future.cc
+++ b/FreeRTOS/cpp11_gcc/future.cc
@@ -1,0 +1,116 @@
+// future -*- C++ -*-
+
+// Copyright (C) 2009-2018 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <future>
+#include <bits/functexcept.h>
+
+namespace
+{
+  struct future_error_category : public std::error_category
+  {
+    virtual const char*
+    name() const noexcept
+    { return "future"; }
+
+    _GLIBCXX_DEFAULT_ABI_TAG
+    virtual std::string message(int __ec) const
+    {
+      std::string __msg;
+      switch (std::future_errc(__ec))
+      {
+      case std::future_errc::broken_promise:
+          __msg = "Broken promise";
+          break;
+      case std::future_errc::future_already_retrieved:
+          __msg = "Future already retrieved";
+          break;
+      case std::future_errc::promise_already_satisfied:
+          __msg = "Promise already satisfied";
+          break;
+      case std::future_errc::no_state:
+          __msg = "No associated state";
+          break;
+      default:
+          __msg = "Unknown error";
+          break;
+      }
+      return __msg;
+    }
+  };
+
+  const future_error_category&
+  __future_category_instance() noexcept
+  {
+    static const future_error_category __fec{};
+    return __fec;
+  }
+}
+
+namespace std _GLIBCXX_VISIBILITY(default)
+{
+_GLIBCXX_BEGIN_NAMESPACE_VERSION
+
+  void
+  __throw_future_error(int __i __attribute__((unused)))
+  { _GLIBCXX_THROW_OR_ABORT(future_error(make_error_code(future_errc(__i)))); }
+
+  const error_category& future_category() noexcept
+  { return __future_category_instance(); }
+
+  future_error::~future_error() noexcept { }
+
+  const char*
+  future_error::what() const noexcept { return logic_error::what(); }
+
+#if defined(_GLIBCXX_HAS_GTHREADS) && defined(_GLIBCXX_USE_C99_STDINT_TR1)
+  __future_base::_Result_base::_Result_base() = default;
+
+  __future_base::_Result_base::~_Result_base() = default;
+
+  void
+  __future_base::_State_baseV2::_Make_ready::_S_run(void* p)
+  {
+    unique_ptr<_Make_ready> mr{static_cast<_Make_ready*>(p)};
+    if (auto state = mr->_M_shared_state.lock())
+      {
+	// Use release MO to synchronize with observers of the ready state.
+	state->_M_status._M_store_notify_all(_Status::__ready,
+	    memory_order_release);
+      }
+  }
+
+  // defined in src/c++11/condition_variable.cc
+  extern void
+  __at_thread_exit(__at_thread_exit_elt* elt);
+
+  void
+  __future_base::_State_baseV2::_Make_ready::_M_set()
+  {
+    _M_cb = &_Make_ready::_S_run;
+    __at_thread_exit(this);
+  }
+#endif
+
+_GLIBCXX_END_NAMESPACE_VERSION
+} // namespace std

--- a/FreeRTOS/cpp11_gcc/gthr_key.h
+++ b/FreeRTOS/cpp11_gcc/gthr_key.h
@@ -31,93 +31,17 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///
 
-#ifndef __THREAD_TEST_H__
-#define __THREAD_TEST_H__
+#ifndef __FREERTOS_GTHR_KEY_H__
+#define __FREERTOS_GTHR_KEY_H__
 
-#include <thread>
-#include <chrono>
-
-inline void DetachBeforeThreadEnd()
+namespace free_rtos_std
 {
-  using namespace std::chrono_literals;
-  std::thread t{[] {
-    std::this_thread::sleep_for(50ms);
-  }};
+struct Key;
 
-  t.detach();
-}
+int freertos_gthread_key_create(Key **keyp, void (*dtor)(void *));
+int freertos_gthread_key_delete(Key *key);
+void *freertos_gthread_getspecific(Key *key);
+int freertos_gthread_setspecific(Key *key, const void *ptr);
+} // namespace free_rtos_std
 
-inline void DetachAfterThreadEnd()
-{
-  using namespace std::chrono_literals;
-  std::thread t{[] {
-  }};
-
-  std::this_thread::sleep_for(50ms);
-  t.detach();
-}
-
-inline void JoinBeforeThreadEnd()
-{
-  using namespace std::chrono_literals;
-  std::thread t{[] {
-    std::this_thread::sleep_for(50ms);
-  }};
-
-  t.join();
-}
-
-inline void JoinAfterThreadEnd()
-{
-  using namespace std::chrono_literals;
-  std::thread t{[] {
-  }};
-
-  std::this_thread::sleep_for(50ms);
-  t.join();
-}
-
-inline void DestroyBeforeThreadEnd()
-{
-  //using namespace std::chrono_literals;
-  // will call std::terminate if enabled
-  //	std::thread t{[]{
-  //			std::this_thread::sleep_for(50ms);
-  //	}};
-}
-
-inline void DestroyNoStart()
-{
-  std::thread t;
-}
-
-inline void StartAndMoveOperator()
-{
-  using namespace std::chrono_literals;
-  std::thread tt;
-
-  {
-    std::thread t{[] {
-      std::this_thread::sleep_for(50ms);
-    }};
-    tt = std::move(t);
-  }
-
-  tt.join();
-}
-
-inline void StartAndMoveConstructor()
-{
-  using namespace std::chrono_literals;
-
-  std::thread t{[] {
-    std::this_thread::sleep_for(50ms);
-  }};
-
-  std::thread tt{std::move(t)};
-
-  //t.join(); this will terminate the program
-  tt.join();
-}
-
-#endif //__THREAD_TEST_H__
+#endif //__FREERTOS_GTHR_KEY_H__

--- a/FreeRTOS/cpp11_gcc/mutex.cc
+++ b/FreeRTOS/cpp11_gcc/mutex.cc
@@ -1,0 +1,97 @@
+// mutex -*- C++ -*-
+
+// Copyright (C) 2008-2018 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <mutex>
+
+#if defined(_GLIBCXX_HAS_GTHREADS) && defined(_GLIBCXX_USE_C99_STDINT_TR1)
+#ifndef _GLIBCXX_HAVE_TLS
+namespace
+{
+  inline std::unique_lock<std::mutex>*&
+  __get_once_functor_lock_ptr()
+  {
+    static std::unique_lock<std::mutex>* __once_functor_lock_ptr = 0;
+    return __once_functor_lock_ptr;
+  }
+}
+#endif
+
+namespace std _GLIBCXX_VISIBILITY(default)
+{
+_GLIBCXX_BEGIN_NAMESPACE_VERSION
+
+#ifdef _GLIBCXX_HAVE_TLS
+  __thread void* __once_callable;
+  __thread void (*__once_call)();
+#else
+  // Explicit instantiation due to -fno-implicit-instantiation.
+  template class function<void()>;
+  function<void()> __once_functor;
+
+  mutex&
+  __get_once_mutex()
+  {
+    static mutex once_mutex;
+    return once_mutex;
+  }
+
+  // code linked against ABI 3.4.12 and later uses this
+  void
+  __set_once_functor_lock_ptr(unique_lock<mutex>* __ptr)
+  {
+    __get_once_functor_lock_ptr() = __ptr;
+  }
+
+  // unsafe - retained for compatibility with ABI 3.4.11
+  unique_lock<mutex>&
+  __get_once_functor_lock()
+  {
+    static unique_lock<mutex> once_functor_lock(__get_once_mutex(), defer_lock);
+    return once_functor_lock;
+  }
+#endif
+
+  extern "C"
+  {
+    void __once_proxy()
+    {
+#ifndef _GLIBCXX_HAVE_TLS
+      function<void()> __once_call = std::move(__once_functor);
+      if (unique_lock<mutex>* __lock = __get_once_functor_lock_ptr())
+      {
+        // caller is using new ABI and provided lock ptr
+        __get_once_functor_lock_ptr() = 0;
+        __lock->unlock();
+      }
+      else
+        __get_once_functor_lock().unlock();  // global lock
+#endif
+      __once_call();
+    }
+  }
+
+_GLIBCXX_END_NAMESPACE_VERSION
+} // namespace std
+
+#endif // _GLIBCXX_HAS_GTHREADS && _GLIBCXX_USE_C99_STDINT_TR1

--- a/FreeRTOS/cpp11_gcc/thread.cpp
+++ b/FreeRTOS/cpp11_gcc/thread.cpp
@@ -36,6 +36,13 @@
 #include <cerrno>
 #include "FreeRTOS.h"
 
+#include "gthr_key_type.h"
+
+namespace free_rtos_std
+{
+extern Key *s_key;
+} // namespace free_rtos_std
+
 namespace std
 {
 
@@ -48,6 +55,9 @@ static void __execute_native_thread_routine(void *__p)
     local.notify_started(); // copy has been made; tell we are running
     __t->_M_run();
   }
+
+  if (free_rtos_std::s_key)
+    free_rtos_std::s_key->CallDestructor(__gthread_t::self().native_task_handle());
 
   local.notify_joined(); // finished; release joined threads
 }

--- a/FreeRTOS/cpp11_gcc/thread_gthread.h
+++ b/FreeRTOS/cpp11_gcc/thread_gthread.h
@@ -39,6 +39,9 @@
 #include "event_groups.h"
 #include "critical_section.h"
 
+#include <utility>   // std::forward
+#include <exception> // std::terminate
+
 namespace std
 {
 class thread;
@@ -128,7 +131,7 @@ public:
     {
       critical_section critical;
 
-      xTaskCreate(foo, "Task", 256, this, tskIDLE_PRIORITY + 1, &_taskHandle);
+      xTaskCreate(foo, "Task", 512, this, tskIDLE_PRIORITY + 1, &_taskHandle);
       if (!_taskHandle)
         std::terminate();
 

--- a/main.cpp
+++ b/main.cpp
@@ -35,11 +35,15 @@
 #include <chrono>
 #include <mutex>
 #include <condition_variable>
+#include <future>
+#include <cassert>
 
 #include "FreeRTOS_time.h"
 
 #include "test_thread.h"
 #include "test_cv.h"
+#include "test_future.h"
+#include "test_once.h"
 
 int main(void)
 {
@@ -49,7 +53,7 @@ int main(void)
 
   while (1)
   {
-    std::this_thread::sleep_until(system_clock::now() + 2s);
+    std::this_thread::sleep_until(system_clock::now() + 200ms);
 
     DetachAfterThreadEnd();
     DetachBeforeThreadEnd();
@@ -60,9 +64,10 @@ int main(void)
     StartAndMoveOperator();
     StartAndMoveConstructor();
 
-    TestCV();
-    TestCVAny();
-    TestCVTimeout();
+    TestConditionVariable();
+
+    TestCallOnce();
+    TestFuture();
   }
 }
 

--- a/test_cv.h
+++ b/test_cv.h
@@ -178,4 +178,34 @@ inline void TestCVAny()
   processor.join();
 }
 
+inline void TestNotifyAllAtThrdExit()
+{
+  std::condition_variable cv;
+  std::mutex mtx;
+  std::int32_t result{};
+  bool fReady{false};
+
+  std::thread{
+      [&] {
+        std::unique_lock<std::mutex> lg{mtx};
+        result = 666;
+        fReady = true;
+        std::notify_all_at_thread_exit(cv, std::move(lg));
+      }}
+      .detach();
+
+  std::unique_lock<std::mutex> lg{mtx};
+  cv.wait(lg, [&fReady] { return fReady; });
+
+  assert(666 == result);
+}
+
+inline void TestConditionVariable()
+{
+  TestCV();
+  TestCVAny();
+  TestCVTimeout();
+  TestNotifyAllAtThrdExit();
+}
+
 #endif //__CV_TEST_H__

--- a/test_future.h
+++ b/test_future.h
@@ -1,0 +1,135 @@
+/// @file
+///
+/// @author: Piotr Grygorczuk grygorek@gmail.com
+///
+/// @copyright Copyright 2019 Piotr Grygorczuk
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without
+/// modification, are permitted provided that the following conditions are met:
+///
+/// o Redistributions of source code must retain the above copyright notice,
+///   this list of conditions and the following disclaimer.
+///
+/// o Redistributions in binary form must reproduce the above copyright notice,
+///   this list of conditions and the following disclaimer in the documentation
+///   and/or other materials provided with the distribution.
+///
+/// o My name may not be used to endorse or promote products derived from this
+///   software without specific prior written permission.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+/// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+/// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+/// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+/// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+/// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+/// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+/// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+/// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+///
+
+#ifndef __FUTURE_TEST_H__
+#define __FUTURE_TEST_H__
+
+#include <future>
+#include <thread>
+#include <chrono>
+#include <cassert>
+#include <cstdint>
+
+inline void TestAsync()
+{
+  std::future<std::int32_t> result0{
+      std::async([]() -> std::int32_t {
+        return 2;
+      })};
+
+  std::future<std::int32_t> result1{
+      std::async(std::launch::async, []() -> std::int32_t {
+        return 3;
+      })};
+
+  std::future<std::int32_t> result2{
+      std::async(std::launch::deferred, []() -> std::int32_t {
+        return 5;
+      })};
+
+  std::int32_t r{result0.get() + result1.get() + result2.get()};
+  assert(2 + 3 + 5 == r);
+}
+
+inline void TestSharedFuture()
+{
+  std::promise<void> go;
+  std::shared_future<void> ready{go.get_future()};
+
+  auto fun1{[ready]() -> std::int32_t {
+    ready.wait();
+    return 5;
+  }};
+
+  auto fun2{[ready]() -> std::int32_t {
+    ready.wait();
+    return 10;
+  }};
+
+  auto result1{std::async(std::launch::async, fun1)};
+  auto result2{std::async(std::launch::async, fun2)};
+
+  go.set_value();
+
+  std::int32_t r{result1.get() + result2.get()};
+  assert(5 + 10 == r);
+}
+
+inline void TestSetValueAtExit()
+{
+  struct Future
+  {
+    std::promise<std::int32_t> p;
+    std::future<std::int32_t> fut{p.get_future()};
+  };
+
+  Future f0, f1;
+
+  using namespace std::chrono_literals;
+  std::thread{
+      [&f0] {
+        std::this_thread::sleep_for(2ms);
+        f0.p.set_value_at_thread_exit(6);
+      }}
+      .detach();
+
+  std::thread{
+      [&f1] {
+        f1.p.set_value_at_thread_exit(7);
+      }}
+      .detach();
+
+  assert(6 == f0.fut.get() && 7 == f1.fut.get());
+}
+
+inline void TestPackagedTask()
+{
+  std::packaged_task<int(int, int)> task([](int a, int b) {
+    return a + b;
+  });
+  std::future<int> result{task.get_future()};
+
+  task(2, 9);
+
+  assert(11 == result.get());
+}
+
+inline void TestFuture()
+{
+  TestAsync();
+  TestSharedFuture();
+  TestSetValueAtExit();
+  TestPackagedTask();
+}
+
+#endif // __FUTURE_TEST_H__


### PR DESCRIPTION
std::futures implementation

- Thread key support implemented (required by std::notify_all_at_thread_exit)
- To support futures, thread require 2kB of stack;
- freertos volatile lists enabled
- Thread test change timeout
   Main reason is to shorten execution time
- ulTaskNotifyTake call as binary semaphore type
  Previously, the call was an equivalent of a counting semaphore.
  Now it is an equivalent of a binary semaphore.