### PR TITLE
Explicitly provide the type as template parameter for std::lock_guard.

### DIFF
--- a/FreeRTOS/cpp11_gcc/gthr_key_type.h
+++ b/FreeRTOS/cpp11_gcc/gthr_key_type.h
@@ -54,7 +54,7 @@ struct Key
     void *val;
 
     {
-      std::lock_guard lg{_mtx};
+      std::lock_guard<std::mutex> lg{_mtx};
 
       auto item{_specValue.find(task)};
       if (item == _specValue.end())


### PR DESCRIPTION
- Code would not compile on STM32CubeIDE using -std=gnu++14. No idea why,
  but at least simple to fix.