### PR TITLE
Fix __gthread_xxx_mutex... locking inverse logic

### DIFF
--- a/FreeRTOS/cpp11_gcc/bits/gthr-default.h
+++ b/FreeRTOS/cpp11_gcc/bits/gthr-default.h
@@ -139,17 +139,17 @@ extern "C"
   static inline int __gthread_recursive_mutex_lock(
       __gthread_recursive_mutex_t *mutex)
   {
-    return xSemaphoreTakeRecursive(*mutex, portMAX_DELAY);
+    return (xSemaphoreTakeRecursive(*mutex, portMAX_DELAY) == pdTRUE) ? 0 : 1;
   }
   static inline int __gthread_recursive_mutex_trylock(
       __gthread_recursive_mutex_t *mutex)
   {
-    return xSemaphoreTakeRecursive(*mutex, 0);
+    return (xSemaphoreTakeRecursive(*mutex, 0) == pdTRUE) ? 0 : 1;
   }
   static inline int __gthread_recursive_mutex_unlock(
       __gthread_recursive_mutex_t *mutex)
   {
-    return xSemaphoreGiveRecursive(*mutex);
+    return (xSemaphoreGiveRecursive(*mutex) == pdTRUE) ? 0 : 1;
   }
 ////////////
 
@@ -182,7 +182,7 @@ extern "C"
     gettimeofday(&now, NULL);
 
     auto t = (*abs_timeout - now).milliseconds();
-    return xSemaphoreTake(*m, pdMS_TO_TICKS(t));
+    return (xSemaphoreTake(*m, pdMS_TO_TICKS(t)) == pdTRUE) ? 0 : 1;
   }
 
   static inline int __gthread_recursive_mutex_timedlock(
@@ -192,7 +192,7 @@ extern "C"
     gettimeofday(&now, NULL);
 
     auto t = (*abs_time - now).milliseconds();
-    return xSemaphoreTakeRecursive(*m, pdMS_TO_TICKS(t));
+    return (xSemaphoreTakeRecursive(*m, pdMS_TO_TICKS(t)) == pdTRUE) ? 0 : 1;
   }
 
   // All functions returning int should return zero on success or the error

--- a/main.cpp
+++ b/main.cpp
@@ -59,7 +59,7 @@ int main(void)
   {
     std::this_thread::sleep_until(system_clock::now() + 200ms);
 
-    TestTimedMtx();
+    TestMtx();
 
     DetachAfterThreadEnd();
     DetachBeforeThreadEnd();

--- a/test_mutex.h
+++ b/test_mutex.h
@@ -39,6 +39,21 @@
 
 #include <cassert>
 
+inline void TestRecursiveMtx()
+{
+  std::recursive_mutex to_mtx;
+
+  // expected the mutex is available
+  to_mtx.lock();
+
+  // expected the mutex is available for the same thread
+  assert(to_mtx.try_lock() == true);
+
+  //call twice according to the ownership level
+  to_mtx.unlock();
+  to_mtx.unlock();
+}
+
 inline void TestTimedMtx()
 {
   using namespace std::chrono_literals;
@@ -64,6 +79,12 @@ inline void TestTimedMtx()
 
   assert(to_mtx.try_lock_until(system_clock::now() + 200ms) == true);
   to_mtx.unlock();
+}
+
+inline void TestMtx()
+{
+  TestRecursiveMtx();
+  TestTimedMtx();
 }
 
 #endif //__MTX_TEST_H__


### PR DESCRIPTION
closing #11 

All family __gthread_mutex_... (e.g. `__gthread_recursive_mutex_lock`, `__gthread_recursive_mutex_trylock`, `__gthread_recursive_mutex_unlock`) functions have reversed logic to FreeRTOS SemaphoreTake/Give.

This commit fixes this bug plus adds mutex tests.