### PR TITLE
Fix exceptions support

### DIFF
--- a/lib_test_nxp_mk64.cmake
+++ b/lib_test_nxp_mk64.cmake
@@ -60,7 +60,8 @@ endif(DEBUG)
 # lto is broken in gcc 8.2
 # set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 SET(COMPILE_COMMON_FLAGS "${CONFIG_DEFS} ${COMPILE_PART_FLAGS} -Wall -Wextra -Wpedantic -fno-common -fmessage-length=0 -ffunction-sections -fdata-sections")
- 
+
+# When enabling exceptions, change the linker script to link libstdc++.a instead of libstdc++_nano.a
 SET(CMAKE_C_FLAGS   "${COMPILE_COMMON_FLAGS} -std=c11 -nostdlib -ffreestanding -fno-builtin " CACHE INTERNAL "" FORCE)
 SET(CMAKE_CXX_FLAGS "${COMPILE_COMMON_FLAGS} -std=c++1z -nostdlib -ffreestanding -fno-builtin -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE INTERNAL "" FORCE)
 SET(CMAKE_ASM_FLAGS "-x assembler-with-cpp ${COMPILE_PART_FLAGS}"  CACHE INTERNAL "" FORCE)

--- a/lib_test_nxp_mk64/Linker.ld
+++ b/lib_test_nxp_mk64/Linker.ld
@@ -101,16 +101,17 @@ SECTIONS
      */
     .ARM.extab : ALIGN(8) 
     {
+      __extab_start = .;
         *(.ARM.extab* .gnu.linkonce.armextab.*)
+      __extab_end = .;
     } > PROGRAM_FLASH
-
-    __exidx_start = .;
 
     .ARM.exidx : ALIGN(8)
     {
+      __exidx_start = .;
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+      __exidx_end = .;
     } > PROGRAM_FLASH
-    __exidx_end = .;
  
     _etext = .;
         

--- a/qemu_lm3s811.cmake
+++ b/qemu_lm3s811.cmake
@@ -60,7 +60,9 @@ endif(DEBUG)
 # lto is broken in gcc 8.2
 # set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 SET(COMPILE_COMMON_FLAGS "${COMPILE_PART_FLAGS} -Wall -Wextra -Wpedantic -fno-common -fmessage-length=0 -ffunction-sections -fdata-sections")
- 
+
+# When enabling exceptions, change the linker script to link libstdc++.a instead of libstdc++_nano.a
+# Note: It is expect LM3S811 has got not enough memory to build with full libstdc++.
 SET(CMAKE_C_FLAGS   "${COMPILE_COMMON_FLAGS} -std=c11 -nostdlib -ffreestanding -fno-builtin " CACHE INTERNAL "" FORCE)
 SET(CMAKE_CXX_FLAGS "${COMPILE_COMMON_FLAGS} -std=c++1z -nostdlib -ffreestanding -fno-builtin -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE INTERNAL "" FORCE)
 SET(CMAKE_ASM_FLAGS "-x assembler-with-cpp ${COMPILE_PART_FLAGS}"  CACHE INTERNAL "" FORCE)

--- a/qemu_lm3s811/linker.ld
+++ b/qemu_lm3s811/linker.ld
@@ -39,14 +39,6 @@ GROUP (
   "crtn.o"
 )
  
- 
-/*
-GROUP (
-  "libstdc++_nano.a"
-  "libsupc++_nano.a"
-  "libc_nano.a"
-) 
-*/ 
 MEMORY
 {
     FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 64K
@@ -97,19 +89,21 @@ SECTIONS
         _etext = .;
     } > FLASH
 
-    .ARM.extab : ALIGN(8)
-	{
-	    *(.ARM.extab* .gnu.linkonce.armextab.*)
-	} > FLASH
-	
-	__exidx_start = .;
-	.ARM.exidx : ALIGN(8)
-	{
-	    *(.ARM.exidx.* .gnu.linkonce.armexidx.*)
-	} > FLASH
-	__exidx_end = .;
-	
-	_etext = .;
+    .ARM.extab : ALIGN(8) 
+    {
+      __extab_start = .;
+      *(.ARM.extab* .gnu.linkonce.armextab.*)
+      __extab_end = .;
+    } > FLASH
+
+    .ARM.exidx : ALIGN(8)
+    {
+      __exidx_start = .;
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+      __exidx_end = .;
+    } > FLASH
+ 
+    _etext = .;
 	
     .data : AT(_etext) ALIGN(8)
     {


### PR DESCRIPTION
resolve #15 

Despite enabling exceptions, each throw ended up in `abort`.

To enable exceptions:

In cmake script remove -fno-exceptions flag and add -fexceptions (to make it explicit).
In the linker script replace libstdc++_nano.a with libstdc++.a (not nano)