### PR TITLE
Suppress `main` related ISO c++ warning

### DIFF
--- a/lib_test_nxp_mk64/startup_mk64f12.cpp
+++ b/lib_test_nxp_mk64/startup_mk64f12.cpp
@@ -310,7 +310,12 @@ extern "C"
 
   void free_rtos_main(void *)
   {
+    // ISO C++ forbits calling 'main' but it must be done for embedded.
+    // So, suppressing warning: ISO C++ forbids taking address of function '::main'
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
     main();
+#pragma GCC diagnostic pop
   }
 
   //*****************************************************************************

--- a/qemu_lm3s811/startup.cpp
+++ b/qemu_lm3s811/startup.cpp
@@ -162,7 +162,12 @@ extern unsigned long _ebss;
 //*****************************************************************************
 static void free_rtos_main(void*)
 {
+  // ISO C++ forbits calling 'main' but it must be done for embedded.
+  // So, suppressing warning: ISO C++ forbids taking address of function '::main'
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
   main();
+#pragma GCC diagnostic pop
 }
 
 __attribute__((section(".after_vectors.reset"))) void ResetISR(void)


### PR DESCRIPTION
ISO C++ does not allow to take an address of the 'main' function. As a result, compiler  issues a warning:

```console
 warning: ISO C++ forbids taking address of function '::main' [-Wpedantic]
   main();
        ^
```

The `main` must be referenced in the bare metal startup code.

This PR suppresses the warning in the startup code.
