### PR TITLE
Make it compile with C++20 in GCC 10.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ cmake_minimum_required(VERSION 3.0)
 
 include(compiler.cmake)
 
+# enable threads
+set(CONFIG_DEFS -D_GLIBCXX_HAS_GTHREADS=1)
+
 if(k64frdmevk)
   project(lib_test_nxp_mk64 C CXX ASM)
   include(lib_test_nxp_mk64.cmake)

--- a/FreeRTOS/cpp11_gcc/bits/gthr-default.h
+++ b/FreeRTOS/cpp11_gcc/bits/gthr-default.h
@@ -35,7 +35,6 @@ typedef free_rtos_std::gthr_freertos __gthread_t;
 extern "C"
 {
 
-#define _GLIBCXX_HAS_GTHREADS
 #define __GTHREADS 1
 
   // returns: 1 - thread system is active; 0 - thread system is not active

--- a/FreeRTOS/cpp11_gcc/condition_variable.h
+++ b/FreeRTOS/cpp11_gcc/condition_variable.h
@@ -27,7 +27,6 @@
 #include "thread_gthread.h"
 
 #include <list>
-#include <algorithm>
 
 namespace free_rtos_std
 {

--- a/FreeRTOS/cpp11_gcc/thread_gthread.h
+++ b/FreeRTOS/cpp11_gcc/thread_gthread.h
@@ -29,280 +29,292 @@
 #include <utility>   // std::forward
 #include <exception> // std::terminate
 
+#if __cplusplus > 201703L
+#include <compare>
+#endif
+
 namespace std
 {
-class thread;
+  class thread;
 }
 
 namespace free_rtos_std
 {
 
-class gthr_freertos
-{
-  // 1. std::thread class has a single member variable representing
-  //    a native thread handle
-  // 2. Detach requires that the native thread function will execute
-  //    even if the std::thread instance has been destroyed. The native
-  //    thread function must take the ownership of any resources allocated
-  //    during the thread creation. This could be the thread handle itself.
-  //    Detach must make sure that the thread has started execution and
-  //    the ownership has been taken.
-  // 3. Join requires a way to switch the current context to a waiting
-  //    state. The native thread function must have a way to unlock
-  //    a joined thread.
-  // 4. FreeRTOS does not have an interface implementing join. It is possible
-  //    to suspend a thread but the thread we are waiting for to join is not
-  //    aware which thread is waiting.  Is this statement wrong?
-  // 5. Solution is to use events group.
-  //    The handle life time must be handled by this class.
-  // 6. Life time of thread handle and events group handle is not the same.
-  //    There are two cases:
-  //     a) detach is called and std::thread instance is destroyed; in this case
-  //        thread function outlives the thread instance
-  //     b) thread function exits first; in this case the thread instance
-  //        outlives the thread function; join must have access to the events
-  //        group to check whether the thread function has finished or not.
-  //    So, the thread handle must exist as long as thread function executes.
-  //    The events group must live as long as std::thread instance exists.
-  // 7. Although the living time is different for two handles,
-  //    see pt. 1 -only one member variable to handle free rtos interface.
-  //    For this reason a single class is a container for the two handles.
-
-  friend std::thread;
-
-  enum
+  class gthr_freertos
   {
-    eEvStoragePos = 0,
-    eStartedEv = 1 << 22,
-    eJoinEv = 1 << 23
-  };
+    // 1. std::thread class has a single member variable representing
+    //    a native thread handle
+    // 2. Detach requires that the native thread function will execute
+    //    even if the std::thread instance has been destroyed. The native
+    //    thread function must take the ownership of any resources allocated
+    //    during the thread creation. This could be the thread handle itself.
+    //    Detach must make sure that the thread has started execution and
+    //    the ownership has been taken.
+    // 3. Join requires a way to switch the current context to a waiting
+    //    state. The native thread function must have a way to unlock
+    //    a joined thread.
+    // 4. FreeRTOS does not have an interface implementing join. It is possible
+    //    to suspend a thread but the thread we are waiting for to join is not
+    //    aware which thread is waiting.  Is this statement wrong?
+    // 5. Solution is to use events group.
+    //    The handle life time must be handled by this class.
+    // 6. Life time of thread handle and events group handle is not the same.
+    //    There are two cases:
+    //     a) detach is called and std::thread instance is destroyed; in this case
+    //        thread function outlives the thread instance
+    //     b) thread function exits first; in this case the thread instance
+    //        outlives the thread function; join must have access to the events
+    //        group to check whether the thread function has finished or not.
+    //    So, the thread handle must exist as long as thread function executes.
+    //    The events group must live as long as std::thread instance exists.
+    // 7. Although the living time is different for two handles,
+    //    see pt. 1 -only one member variable to handle free rtos interface.
+    //    For this reason a single class is a container for the two handles.
 
-public:
-  typedef void (*task_foo)(void *);
-  typedef TaskHandle_t native_task_type;
+    friend std::thread;
 
-  gthr_freertos(const gthr_freertos &r)
-  {
-    critical_section critical;
-
-    _taskHandle = r._taskHandle;
-    _evHandle = r._evHandle;
-    _arg = r._arg;
-    _fOwner = false; // it is just a copy
-  }
-
-  gthr_freertos(gthr_freertos &&r)
-  {
-    taskENTER_CRITICAL();
-    if (r._fOwner)
+    enum
     {
-      taskEXIT_CRITICAL();
-      // make sure it has already started
-      // - native thread function must make local copies first
-      r.wait_for_start();
-      taskENTER_CRITICAL();
-    }
-    // 'this' becomes the owner if r is the owner
-    move(std::forward<gthr_freertos>(r));
-    taskEXIT_CRITICAL();
-  }
+      eEvStoragePos = 0,
+      eStartedEv = 1 << 22,
+      eJoinEv = 1 << 23
+    };
 
-  bool create_thread(task_foo foo, void *arg)
-  {
-    _arg = arg;
+  public:
+    typedef void (*task_foo)(void *);
+    typedef TaskHandle_t native_task_type;
 
-    _evHandle = xEventGroupCreate();
-    if (!_evHandle)
-      std::terminate();
-
+    gthr_freertos(const gthr_freertos &r)
     {
       critical_section critical;
 
-      xTaskCreate(foo, "Task", 512, this, tskIDLE_PRIORITY + 1, &_taskHandle);
-      if (!_taskHandle)
+      _taskHandle = r._taskHandle;
+      _evHandle = r._evHandle;
+      _arg = r._arg;
+      _fOwner = false; // it is just a copy
+    }
+
+    gthr_freertos(gthr_freertos &&r)
+    {
+      taskENTER_CRITICAL();
+      if (r._fOwner)
+      {
+        taskEXIT_CRITICAL();
+        // make sure it has already started
+        // - native thread function must make local copies first
+        r.wait_for_start();
+        taskENTER_CRITICAL();
+      }
+      // 'this' becomes the owner if r is the owner
+      move(std::forward<gthr_freertos>(r));
+      taskEXIT_CRITICAL();
+    }
+
+    bool create_thread(task_foo foo, void *arg)
+    {
+      _arg = arg;
+
+      _evHandle = xEventGroupCreate();
+      if (!_evHandle)
         std::terminate();
 
-      vTaskSetThreadLocalStoragePointer(_taskHandle, eEvStoragePos, _evHandle);
-      _fOwner = true;
+      {
+        critical_section critical;
+
+        xTaskCreate(foo, "Task", 512, this, tskIDLE_PRIORITY + 1, &_taskHandle);
+        if (!_taskHandle)
+          std::terminate();
+
+        vTaskSetThreadLocalStoragePointer(_taskHandle, eEvStoragePos, _evHandle);
+        _fOwner = true;
+      }
+
+      return true;
     }
 
-    return true;
-  }
+    void join()
+    { // note 1: _evHandle must be valid here. Even if the native thread function
+      //   has finished and got destroyed the _taskHandle, it
+      //   must not release the _evHandle!
+      //
+      // note 2: The native thread function must call notify_joined when it has
+      //   finished. Even if 'join' is called after that, the bits are set
+      //   and event group will not block. So it is safe to call wait here.
+      //
+      // note 3: Instead of keeping _evHandle, it could be possible to read
+      //   it from the local storage of the task. However, that would require
+      //   checking if the task still exists and use critical section if it does.
+      //   It is faster to use _evHandle directly, even if it is an extra item to
+      //   copy each time when this instance is copied.
+      while (0 == xEventGroupWaitBits(_evHandle,
+                                      eJoinEv | eStartedEv,
+                                      pdFALSE,
+                                      pdTRUE,
+                                      portMAX_DELAY))
+        ;
+    }
 
-  void join()
-  { // note 1: _evHandle must be valid here. Even if the native thread function
-    //   has finished and got destroyed the _taskHandle, it
-    //   must not release the _evHandle!
-    //
-    // note 2: The native thread function must call notify_joined when it has
-    //   finished. Even if 'join' is called after that, the bits are set
-    //   and event group will not block. So it is safe to call wait here.
-    //
-    // note 3: Instead of keeping _evHandle, it could be possible to read
-    //   it from the local storage of the task. However, that would require
-    //   checking if the task still exists and use critical section if it does.
-    //   It is faster to use _evHandle directly, even if it is an extra item to
-    //   copy each time when this instance is copied.
-    while (0 == xEventGroupWaitBits(_evHandle,
-                                    eJoinEv | eStartedEv,
-                                    pdFALSE,
-                                    pdTRUE,
-                                    portMAX_DELAY))
-      ;
-  }
+    void detach()
+    { // Detaching is removing the event's object. It can be done
+      // only if the thread has started execution.
+      wait_for_start();
 
-  void detach()
-  { // Detaching is removing the event's object. It can be done
-    // only if the thread has started execution.
-    wait_for_start();
+      { // unfortunately critical section is needed here to make sure
+        // the task is not deleted while accessing the task's local storage.
+        critical_section critical;
 
-    { // unfortunately critical section is needed here to make sure
-      // the task is not deleted while accessing the task's local storage.
-      critical_section critical;
+        if (eDeleted != eTaskGetState(_taskHandle))
+        {
+          vTaskSetThreadLocalStoragePointer(_taskHandle, eEvStoragePos, nullptr);
+          vEventGroupDelete(_evHandle);
 
-      if (eDeleted != eTaskGetState(_taskHandle))
+          // Thread still exists but detach removes ownership.
+          // Ownership belongs to the native thread. It will release the task
+          // handle once user's thread function exits.
+          _fOwner = false;
+        }
+      }
+    }
+
+    void notify_started()
+    { // Function should be called only from the controlled task
+      // and only when the (internal, not application's one) thread function
+      // has started execution.
+      xEventGroupSetBits(_evHandle, eStartedEv);
+    }
+
+    void notify_joined()
+    { // Function should be called only from the controlled task
+      // and only when the thread function has finished execution.
       {
-        vTaskSetThreadLocalStoragePointer(_taskHandle, eEvStoragePos, nullptr);
-        vEventGroupDelete(_evHandle);
+        critical_section critical;
 
-        // Thread still exists but detach removes ownership.
-        // Ownership belongs to the native thread. It will release the task
-        // handle once user's thread function exits.
+        // Note: The _evHandle may be invalid if thread has been detached.
+        //    It is required to get the handle from the thread itself.
+        //    The detach function will set this handle to nullptr.
+        auto evHnd = static_cast<EventGroupHandle_t>(
+            pvTaskGetThreadLocalStoragePointer(_taskHandle, eEvStoragePos));
+
+        if (evHnd)
+        {
+          xEventGroupSetBits(evHnd, eJoinEv);
+        }
+        else
+        {
+          // thread has been detached, nothing to do
+        }
+      }
+
+      // vTaskDelete will not return
+      vTaskDelete(nullptr);
+    }
+
+    static gthr_freertos self()
+    {
+      auto tHnd = xTaskGetCurrentTaskHandle();
+      auto evHnd = static_cast<EventGroupHandle_t>(
+          pvTaskGetThreadLocalStoragePointer(tHnd, eEvStoragePos));
+      return gthr_freertos{tHnd, evHnd};
+    }
+
+    static native_task_type native_task_handle()
+    {
+      return xTaskGetCurrentTaskHandle();
+    }
+
+    constexpr friend bool operator==(const gthr_freertos &l, const gthr_freertos &r) noexcept
+    {
+      return l._taskHandle == r._taskHandle;
+    }
+#if __cpp_lib_three_way_comparison
+    constexpr friend std::strong_ordering operator<=>(const gthr_freertos &l, const gthr_freertos &r) noexcept
+    {
+      return l._taskHandle <=> r._taskHandle;
+    }
+#else
+    constexpr friend bool operator!=(const gthr_freertos &l, const gthr_freertos &r) noexcept
+    {
+      return l._taskHandle != r._taskHandle;
+    }
+    constexpr friend bool operator<(const gthr_freertos &l, const gthr_freertos &r) noexcept
+    {
+      return l._taskHandle < r._taskHandle;
+    }
+#endif
+
+    constexpr void *arg() const
+    {
+      return _arg;
+    }
+
+    ~gthr_freertos() = default;
+    gthr_freertos &operator=(const gthr_freertos &r) = delete;
+
+    gthr_freertos() = default;
+
+    constexpr gthr_freertos(native_task_type thnd, EventGroupHandle_t ehnd)
+        : _taskHandle{thnd}, _evHandle{ehnd}
+    {
+    }
+
+    gthr_freertos &operator=(gthr_freertos &&r)
+    {
+      if (this == &r)
+        return *this;
+
+      taskENTER_CRITICAL();
+
+      if (_fOwner)
+      { // If 'r' is the owner then 'this' will get the
+        // new ownership. If 'r' is not the owner then
+        // just a copy is being moved. Either way 'this'
+        // ownership is lost and handles must be deleted.
+        if (eDeleted != eTaskGetState(_taskHandle))
+          vTaskDelete(_taskHandle);
+        if (_evHandle)
+          vEventGroupDelete(_evHandle);
         _fOwner = false;
       }
-    }
-  }
-
-  void notify_started()
-  { // Function should be called only from the controlled task
-    // and only when the (internal, not application's one) thread function
-    // has started execution.
-    xEventGroupSetBits(_evHandle, eStartedEv);
-  }
-
-  void notify_joined()
-  { // Function should be called only from the controlled task
-    // and only when the thread function has finished execution.
-    {
-      critical_section critical;
-
-      // Note: The _evHandle may be invalid if thread has been detached.
-      //    It is required to get the handle from the thread itself.
-      //    The detach function will set this handle to nullptr.
-      auto evHnd = static_cast<EventGroupHandle_t>(
-          pvTaskGetThreadLocalStoragePointer(_taskHandle, eEvStoragePos));
-
-      if (evHnd)
+      else if (r._fOwner)
       {
-        xEventGroupSetBits(evHnd, eJoinEv);
+        taskEXIT_CRITICAL();
+        // make sure it has already started
+        // - native thread function must make local copies first
+        r.wait_for_start();
+        taskENTER_CRITICAL();
       }
-      else
-      {
-        // thread has been detached, nothing to do
-      }
-    }
-
-    // vTaskDelete will not return
-    vTaskDelete(nullptr);
-  }
-
-  static gthr_freertos self()
-  {
-    auto tHnd = xTaskGetCurrentTaskHandle();
-    auto evHnd = static_cast<EventGroupHandle_t>(
-        pvTaskGetThreadLocalStoragePointer(tHnd, eEvStoragePos));
-    return gthr_freertos{tHnd, evHnd};
-  }
-
-  static native_task_type native_task_handle()
-  {
-    return xTaskGetCurrentTaskHandle();
-  }
-
-  bool operator==(const gthr_freertos &r) const
-  {
-    return _taskHandle == r._taskHandle;
-  }
-
-  bool operator!=(const gthr_freertos &r) const
-  {
-    return !operator==(r);
-  }
-
-  bool operator<(const gthr_freertos &r) const
-  {
-    return _taskHandle < r._taskHandle;
-  }
-
-  void *arg() const { return _arg; }
-
-  ~gthr_freertos() = default;
-  gthr_freertos &operator=(const gthr_freertos &r) = delete;
-
-private:
-  gthr_freertos() = default;
-
-  gthr_freertos(native_task_type thnd, EventGroupHandle_t ehnd)
-      : _taskHandle{thnd}, _evHandle{ehnd}
-  {
-  }
-
-  gthr_freertos &operator=(gthr_freertos &&r)
-  {
-    if (this == &r)
-      return *this;
-
-    taskENTER_CRITICAL();
-
-    if (_fOwner)
-    { // If 'r' is the owner then 'this' will get the
-      // new ownership. If 'r' is not the owner then
-      // just a copy is being moved. Either way 'this'
-      // ownership is lost and handles must be deleted.
-      if (eDeleted != eTaskGetState(_taskHandle))
-        vTaskDelete(_taskHandle);
-      if (_evHandle)
-        vEventGroupDelete(_evHandle);
-      _fOwner = false;
-    }
-    else if (r._fOwner)
-    {
+      // 'this' becomes the owner if r is the owner
+      move(std::forward<gthr_freertos>(r));
       taskEXIT_CRITICAL();
-      // make sure it has already started
-      // - native thread function must make local copies first
-      r.wait_for_start();
-      taskENTER_CRITICAL();
+      return *this;
     }
-    // 'this' becomes the owner if r is the owner
-    move(std::forward<gthr_freertos>(r));
-    taskEXIT_CRITICAL();
-    return *this;
-  }
 
-  void move(gthr_freertos &&r)
-  {
-    _taskHandle = r._taskHandle;
-    _evHandle = r._evHandle;
-    _arg = r._arg;
-    _fOwner = r._fOwner;
-    r._taskHandle = nullptr;
-    r._evHandle = nullptr;
-    r._arg = nullptr;
-    r._fOwner = false;
-  }
+  private:
+    constexpr void move(gthr_freertos &&r)
+    {
+      _taskHandle = r._taskHandle;
+      _evHandle = r._evHandle;
+      _arg = r._arg;
+      _fOwner = r._fOwner;
+      r._taskHandle = nullptr;
+      r._evHandle = nullptr;
+      r._arg = nullptr;
+      r._fOwner = false;
+    }
 
-  void wait_for_start()
-  {
-    while (0 == xEventGroupWaitBits(
-                    _evHandle, eStartedEv, pdFALSE, pdTRUE, portMAX_DELAY))
-      ;
-  }
+    void wait_for_start()
+    {
+      while (0 == xEventGroupWaitBits(
+                      _evHandle, eStartedEv, pdFALSE, pdTRUE, portMAX_DELAY))
+        ;
+    }
 
-  native_task_type _taskHandle{nullptr};
-  EventGroupHandle_t _evHandle{nullptr};
-  void *_arg{nullptr};
-  bool _fOwner{false};
-};
+    native_task_type _taskHandle{nullptr};
+    EventGroupHandle_t _evHandle{nullptr};
+    void *_arg{nullptr};
+    bool _fOwner{false};
+  };
 
 } // namespace free_rtos_std
 

--- a/lib_test_nxp_mk64.cmake
+++ b/lib_test_nxp_mk64.cmake
@@ -46,11 +46,12 @@ endif(DEBUG)
 
 # lto is broken in gcc 8.2
 # set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-SET(COMPILE_COMMON_FLAGS "${CONFIG_DEFS} ${COMPILE_PART_FLAGS} -Wall -Wextra -Wpedantic -fno-common -fmessage-length=0 -ffunction-sections -fdata-sections")
+SET(COMPILE_COMMON_FLAGS "${CONFIG_DEFS} ${COMPILE_PART_FLAGS} -Wall -Wextra -Wpedantic -fno-common  \
+                        -fmessage-length=0 -ffunction-sections -fdata-sections")
 
 # When enabling exceptions, change the linker script to link libstdc++.a instead of libstdc++_nano.a
-SET(CMAKE_C_FLAGS   "${COMPILE_COMMON_FLAGS} -std=c11 -nostdlib -ffreestanding -fno-builtin " CACHE INTERNAL "" FORCE)
-SET(CMAKE_CXX_FLAGS "${COMPILE_COMMON_FLAGS} -std=c++1z -nostdlib -ffreestanding -fno-builtin -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE INTERNAL "" FORCE)
+SET(CMAKE_C_FLAGS   "${COMPILE_COMMON_FLAGS} -std=c17 -nostdlib -ffreestanding -fno-builtin " CACHE INTERNAL "" FORCE)
+SET(CMAKE_CXX_FLAGS "${COMPILE_COMMON_FLAGS} -std=c++2a -nostdlib -ffreestanding -fno-builtin -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE INTERNAL "" FORCE)
 SET(CMAKE_ASM_FLAGS "-x assembler-with-cpp ${COMPILE_PART_FLAGS}"  CACHE INTERNAL "" FORCE)
 
 include_directories( 

--- a/qemu_lm3s811.cmake
+++ b/qemu_lm3s811.cmake
@@ -46,12 +46,13 @@ endif(DEBUG)
 
 # lto is broken in gcc 8.2
 # set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-SET(COMPILE_COMMON_FLAGS "${COMPILE_PART_FLAGS} -Wall -Wextra -Wpedantic -fno-common -fmessage-length=0 -ffunction-sections -fdata-sections")
+SET(COMPILE_COMMON_FLAGS "${CONFIG_DEFS} ${COMPILE_PART_FLAGS} -Wall -Wextra -Wpedantic -fno-common  \
+                        -fmessage-length=0 -ffunction-sections -fdata-sections")
 
 # When enabling exceptions, change the linker script to link libstdc++.a instead of libstdc++_nano.a
 # Note: It is expect LM3S811 has got not enough memory to build with full libstdc++.
-SET(CMAKE_C_FLAGS   "${COMPILE_COMMON_FLAGS} -std=c11 -nostdlib -ffreestanding -fno-builtin " CACHE INTERNAL "" FORCE)
-SET(CMAKE_CXX_FLAGS "${COMPILE_COMMON_FLAGS} -std=c++1z -nostdlib -ffreestanding -fno-builtin -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE INTERNAL "" FORCE)
+SET(CMAKE_C_FLAGS   "${COMPILE_COMMON_FLAGS} -std=c17 -nostdlib -ffreestanding -fno-builtin " CACHE INTERNAL "" FORCE)
+SET(CMAKE_CXX_FLAGS "${COMPILE_COMMON_FLAGS} -std=c++2a -nostdlib -ffreestanding -fno-builtin -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE INTERNAL "" FORCE)
 SET(CMAKE_ASM_FLAGS "-x assembler-with-cpp ${COMPILE_PART_FLAGS}"  CACHE INTERNAL "" FORCE)
 
 # definition required by the demo project


### PR DESCRIPTION
closes #20 

Compiling with GCC 10.2.1 with flags -std=c++2a and -std=c17

### Changes in `gthr_freertos` class
* add <=> operator
* add <compare> header required by the <=> operator
* make copy operators public - required by stop_token

### Changes in `condition_variable.h`
* remove not needed `<algorithm>` include

### Build script
* Definition of `_GLIBCXX_HAS_GTHREADS` moved to cmake script. Definition of `_GLIBCXX_HAS_GTHREADS` in `gthr-default.h` is not enough for the project to build. 

### Things to consider
* jthread - not tested yet, from the code it seems stop_token has dependency on a semaphore header
* semaphores - <semaphore> header is not present in GCC 10.2.1
* <barier> and <latch> headers are not present in GCC 10.2.1
