### PR TITLE
replace deprecated vSemaphoreCreateBinary

### DIFF
--- a/FreeRTOS/cpp11_gcc/condition_variable.h
+++ b/FreeRTOS/cpp11_gcc/condition_variable.h
@@ -27,6 +27,7 @@
 #include "thread_gthread.h"
 
 #include <list>
+#include <bits/functexcept.h>
 
 namespace free_rtos_std
 {
@@ -34,11 +35,11 @@ namespace free_rtos_std
 class semaphore
 {
 public:
-  semaphore()
+  semaphore() : _xSemaphore { xSemaphoreCreateBinary() }
   {
-    vSemaphoreCreateBinary(_xSemaphore);
     if (!_xSemaphore)
       std::__throw_system_error(12); // POSIX error: no memory
+    xSemaphoreGive(_xSemaphore);
   }
 
   void lock() { xSemaphoreTake(_xSemaphore, portMAX_DELAY); }


### PR DESCRIPTION
closes #18 

Description
------------

* use xSemaphoreCreateBinary instead of a deprecated vSemaphoreCreateBinary
* add a header for __throw_system_error