### PR TITLE
Enable setting stack size for individual std::thread instances

### DIFF
--- a/FreeRTOS/cpp11_gcc/thread.cpp
+++ b/FreeRTOS/cpp11_gcc/thread.cpp
@@ -1,4 +1,5 @@
 /// Copyright 2021 Piotr Grygorczuk <grygorek@gmail.com>
+/// Copyright 2023 by NXP. All rights reserved.
 ///
 /// Permission is hereby granted, free of charge, to any person obtaining a copy
 /// of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +29,9 @@
 namespace free_rtos_std
 {
   extern Key *s_key;
+
+  size_t stacksize_lock_section::_stackWordCount{
+      stacksize_lock_section::DEFAULT_STACK_WORDCOUNT};
 } // namespace free_rtos_std
 
 namespace std

--- a/FreeRTOS/cpp11_gcc/thread.cpp
+++ b/FreeRTOS/cpp11_gcc/thread.cpp
@@ -30,7 +30,7 @@ namespace free_rtos_std
 {
   extern Key *s_key;
 
-  size_t stacksize_lock_section::_stackWordCount{
+  configSTACK_DEPTH_TYPE stacksize_lock_section::_stackWordCount{
       stacksize_lock_section::DEFAULT_STACK_WORDCOUNT};
 } // namespace free_rtos_std
 

--- a/FreeRTOS/cpp11_gcc/thread_gthread.h
+++ b/FreeRTOS/cpp11_gcc/thread_gthread.h
@@ -44,7 +44,7 @@ namespace free_rtos_std
   class stacksize_lock_section : critical_section
   {
     // It is possible to manually specify the task stack size when creating a
-    // std::thread instance as follows:
+    // `std::thread` instance as follows:
     // ```
     // std::thread t{[&] {
     //     free_rtos_std::stacksize_lock_section lock{4096U}; // 16 kB
@@ -52,7 +52,7 @@ namespace free_rtos_std
     // }()};
     // ```
     // This way, we are sure that only this one thread will have the specified
-    // stack size, while keeping the convenient std::thread API.
+    // stack size, while keeping the convenient `std::thread` API.
     //
     // Please note that the following will result in a deadlock:
     // ```
@@ -63,16 +63,20 @@ namespace free_rtos_std
     // }
     // ```
     // The reason is that the move assignment operator of std::thread calls the
-    // gthr_freertos::wait_for_start method, which waits for a different task.
-    // Since scheduling is disabled during the lifetime of
-    // stacksize_lock_section, that waiting will never return. Instead, if the
-    // std::thread object only needs to assigned, we can proceed as follows:
+    // `gthr_freertos::wait_for_start` method, which waits for a different
+    // task. Since scheduling is disabled during the lifetime of
+    // `stacksize_lock_section`, that waiting will never return. Instead, if
+    // the `std::thread` object only needs to assigned, we can proceed as
+    // follows:
     // ```
     // t = [&] {
     //   free_rtos_std::stacksize_lock_section lock{4096U}; // 16 kB
     //   return std::thread{fn, args};
     // }();
     // ```
+    // In this case, the move assignment operator is called only after the
+    // `stacksize_lock_section` instance is destroyed, so the scheduler is
+    // running again.
 
   public:
     explicit stacksize_lock_section(configSTACK_DEPTH_TYPE stackWordCount) noexcept

--- a/FreeRTOS/cpp11_gcc/thread_gthread.h
+++ b/FreeRTOS/cpp11_gcc/thread_gthread.h
@@ -75,7 +75,7 @@ namespace free_rtos_std
     // ```
 
   public:
-    explicit stacksize_lock_section(size_t stackWordCount) noexcept
+    explicit stacksize_lock_section(configSTACK_DEPTH_TYPE stackWordCount) noexcept
     {
       _stackWordCount = stackWordCount;
     }
@@ -85,16 +85,16 @@ namespace free_rtos_std
       _stackWordCount = DEFAULT_STACK_WORDCOUNT;
     }
 
-    static size_t stack_word_count() noexcept
+    static configSTACK_DEPTH_TYPE stack_word_count() noexcept
     {
       return _stackWordCount;
     }
 
     // Default stack size is 512 words, so 2 kB
-    static constexpr size_t DEFAULT_STACK_WORDCOUNT{512U};
+    static constexpr configSTACK_DEPTH_TYPE DEFAULT_STACK_WORDCOUNT{512U};
 
   private:
-    static size_t _stackWordCount;
+    static configSTACK_DEPTH_TYPE _stackWordCount;
   };
 
   class gthr_freertos

--- a/lib_test_CA9/main.cpp
+++ b/lib_test_CA9/main.cpp
@@ -68,6 +68,8 @@ int main(void)
     DestroyNoStart();
     StartAndMoveOperator();
     StartAndMoveConstructor();
+    StartWithStackSize();
+    AssignWithStackSize();
 
 #if __cplusplus > 201907L
     TestJThread();

--- a/lib_test_RISC-V/main.cpp
+++ b/lib_test_RISC-V/main.cpp
@@ -68,6 +68,8 @@ int main(void)
     DestroyNoStart();
     StartAndMoveOperator();
     StartAndMoveConstructor();
+    StartWithStackSize();
+    AssignWithStackSize();
 
 #if __cplusplus > 201907L
     TestJThread();

--- a/lib_test_nxp_mk64/main.cpp
+++ b/lib_test_nxp_mk64/main.cpp
@@ -62,6 +62,8 @@ int main(void)
     DestroyNoStart();
     StartAndMoveOperator();
     StartAndMoveConstructor();
+    StartWithStackSize();
+    AssignWithStackSize();
 
 #if __cplusplus > 201907L
     TestJThread();

--- a/qemu_lm3s811.cmake
+++ b/qemu_lm3s811.cmake
@@ -92,10 +92,10 @@ add_executable(${PROJECT_NAME}.elf
   qemu_lm3s811/hw_include/src/uart.c
   qemu_lm3s811/hw_include/src/osram96x16.c
 
-  qemu_lm3s811/freertos_Demo/Common/Minimal/integer.c
-  qemu_lm3s811/freertos_Demo/Common/Minimal/BlockQ.c
-  qemu_lm3s811/freertos_Demo/Common/Minimal/PollQ.c
-  qemu_lm3s811/freertos_Demo/Common/Minimal/semtest.c
+  qemu_lm3s811/freertos_demo/Common/Minimal/integer.c
+  qemu_lm3s811/freertos_demo/Common/Minimal/BlockQ.c
+  qemu_lm3s811/freertos_demo/Common/Minimal/PollQ.c
+  qemu_lm3s811/freertos_demo/Common/Minimal/semtest.c
 )
 
 find_library(driver libdriver.a PATHS ${CMAKE_SOURCE_DIR}/qemu_lm3s811/hw_include REQUIRED)


### PR DESCRIPTION
Currently, it is a significant limitation of this library that there is a global stack size that is used for every `std::thread` creation. For a little experimental (unreleased) project of mine, I needed to keep using the `std::thread` API (I dont want to do a lot of refactors to drop down to the FreeRTOS stack API) but also be able to set stack sizes for some particular threads which needs more stack space than default. I tried very hard to make it work using `std::thread::native_handle` (which returns the underlying `free_rtos_std::gthr_freertos` instance)  and adding some secret method to the `free_rtos_std::gthr_freertos` type, but ultimately that cannot work since it would bypass all the machinery needed in libstdc++ `std::thread` implementation (such as `std::thread::__execute_native_thread_routine`).

So, I decided to just keep a single global flag with the stack size to be used when a thread is started. Of course, a plain global variable wouldnt be safe, since any task could change it and there would be data races when multiple tasks would create new tasks concurrently. To avoid these problem, I implemented a special "critical section" version, which sets the global variable and also disable scheduling to avoid the data races.

Please let me know what you think about this patch, if you want to merge it or not. Of course, it is a non-standard extension, but at least for me, it made it possible to experiment with your nice library! :)