### PR TITLE
Make default stack size configurable and add to README

### DIFF
--- a/FreeRTOS/cpp11_gcc/thread_gthread.h
+++ b/FreeRTOS/cpp11_gcc/thread_gthread.h
@@ -94,8 +94,12 @@ namespace free_rtos_std
       return _stackWordCount;
     }
 
+#ifdef configDEFAULT_STD_THREAD_STACK_SIZE
+    static constexpr configSTACK_DEPTH_TYPE DEFAULT_STACK_WORDCOUNT{configDEFAULT_STD_THREAD_STACK_SIZE};
+#else
     // Default stack size is 512 words, so 2 kB
-    static constexpr configSTACK_DEPTH_TYPE DEFAULT_STACK_WORDCOUNT{512U};
+    static constexpr configSTACK_DEPTH_TYPE DEFAULT_STACK_WORDCOUNT{512};
+#endif
 
   private:
     static configSTACK_DEPTH_TYPE _stackWordCount;

--- a/FreeRTOS/cpp11_gcc/thread_gthread.h
+++ b/FreeRTOS/cpp11_gcc/thread_gthread.h
@@ -98,7 +98,7 @@ namespace free_rtos_std
     static constexpr configSTACK_DEPTH_TYPE DEFAULT_STACK_WORDCOUNT{configDEFAULT_STD_THREAD_STACK_SIZE};
 #else
     // Default stack size is 512 words, so 2 kB
-    static constexpr configSTACK_DEPTH_TYPE DEFAULT_STACK_WORDCOUNT{512};
+    static constexpr configSTACK_DEPTH_TYPE DEFAULT_STACK_WORDCOUNT{512U};
 #endif
 
   private:

--- a/README.md
+++ b/README.md
@@ -850,7 +850,8 @@ bool gthr_freertos::create_thread(task_foo foo, void *arg)
   {
     critical_section critical;
 
-    xTaskCreate(foo, "Task", 512, this, tskIDLE_PRIORITY + 1, &_taskHandle);
+    xTaskCreate(foo, "Task", stacksize_lock_section::stack_word_count(),
+                    this, tskIDLE_PRIORITY + 1, &_taskHandle);
     if (!_taskHandle)
       std::terminate();
 
@@ -889,8 +890,8 @@ The reason is that the move assignment operator of std::thread calls the
 `gthr_freertos::wait_for_start` method, which waits for a different
 task. Since scheduling is disabled during the lifetime of
 `stacksize_lock_section`, that waiting will never return. Instead, if
-the `std::thread` object only needs to assigned, we can proceed as
-follows.
+the `std::thread` object only needs to be assigned, we can
+proceed as follows.
 
 ```
 t = [&] {

--- a/README.md
+++ b/README.md
@@ -827,10 +827,11 @@ created in a constructor but in create_thread function. Program will
 terminate if there is no resources. Alternatively, the function
 could return false instead. By default 512 words will be allocated
 for the stack. This would be 2kB on ARM. Standard C++ interface does not let
-define the stack size. So, this code has to be modified if application 
-requires more. Note, that the change will apply to all threads. The 2kB is 
-required when futures are used. Without futures, I had the system running 
-with 1kB only. 
+define the stack size. It is possible to configure the default stack size (in
+words) by setting the macro `configDEFAULT_STD_THREAD_STACK_SIZE` in your
+`FreeRTOSConfig.h` file. Note, that the change will apply to all threads. The
+2kB is required when futures are used. Without futures, I had the system
+running with 1kB only. 
 
 Critical section disables interrupts. As described earlier,
 the native thread function will delete thread's handle when finished.
@@ -860,6 +861,47 @@ bool gthr_freertos::create_thread(task_foo foo, void *arg)
   return true;
 }
 ```
+
+The critical section feature is used to implement a way to manually specify the
+task stack size when creating a thread.
+
+```
+std::thread t{[&] {
+    free_rtos_std::stacksize_lock_section lock{4096U}; // 16 kB
+    return std::thread{fn, args};
+}()};
+```
+
+This way, we are sure that only this one thread will have the specified
+stack size, while keeping the convenient `std::thread` API.
+
+Please note that the following will result in a deadlock.
+
+```
+std::thread t;
+{
+  free_rtos_std::stacksize_lock_section lock{4096U}; // 16 kB
+  t = std::thread{fn, args};
+}
+```
+
+The reason is that the move assignment operator of std::thread calls the
+`gthr_freertos::wait_for_start` method, which waits for a different
+task. Since scheduling is disabled during the lifetime of
+`stacksize_lock_section`, that waiting will never return. Instead, if
+the `std::thread` object only needs to assigned, we can proceed as
+follows.
+
+```
+t = [&] {
+  free_rtos_std::stacksize_lock_section lock{4096U}; // 16 kB
+  return std::thread{fn, args};
+}();
+```
+
+In this case, the move assignment operator is called only after the
+`stacksize_lock_section` instance is destroyed, so the scheduler is
+running again.
 
 ### Join
 


### PR DESCRIPTION
It can be very useful to configure the default stack size used when creating `std::thread` instances. This can now be done easily with a `config*`-style macro that one can set in their `FreeRTOSConfig.h` header.

Also, add stack size configuration mechanism to README.