### PR TITLE
return correct value of semihosting exit command

### DIFF
--- a/lib_test_CA9/startup_ARMCA9.cpp
+++ b/lib_test_CA9/startup_ARMCA9.cpp
@@ -234,7 +234,7 @@ int sys_semihost(int reason, volatile void *arg)
 extern "C" void _exit(int exit_code)
 {
   constexpr int SYS_EXIT_EXTENDED = 0x20u;
-  constexpr int ADP_Stopped_ApplicationExit = 0x200026u;
+  constexpr int ADP_Stopped_ApplicationExit = 0x20026u;
   volatile int ret[2] = {ADP_Stopped_ApplicationExit, exit_code};
   sys_semihost(SYS_EXIT_EXTENDED, ret);
 }

--- a/lib_test_RISC-V/startup_riscv.cpp
+++ b/lib_test_RISC-V/startup_riscv.cpp
@@ -83,7 +83,7 @@ extern "C"
   void _exit(int exit_code)
   {
     constexpr int SYS_EXIT_EXTENDED = 0x20u;
-    constexpr int ADP_Stopped_ApplicationExit = 0x200026u;
+    constexpr int ADP_Stopped_ApplicationExit = 0x20026u;
     int ret[2] = {ADP_Stopped_ApplicationExit, exit_code};
     sys_semihost(SYS_EXIT_EXTENDED, ret);
   }


### PR DESCRIPTION
Bug fix.
Fix semihosting exit reason code. Although the exit code was correct, qemu was still reporting an error. Turned out the code for the exit reason was incorrect and qemu was not recognizing it.